### PR TITLE
Update babel config to match `@bedrock/webpack`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Added `@bedrock/core` config object field to help set fallbacks:
   `config.karma.config.webpack.resolve.fallback`
 - Refactor to use more modern karma API.
+- Update babel config that matches `@bedrock/webpack`:
+  - Add minor `corejs` version.
+  - Use `bugfixes`.
+  - Add target of `defaults, not IE 11`. This helps with new `BigInt` issues.
 
 ## 5.0.0 - 2022-04-29
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -63,7 +63,9 @@ config.karma.config = {
                     '@babel/preset-env',
                     {
                       useBuiltIns: 'entry',
-                      corejs: 3
+                      corejs: '3.22',
+                      bugfixes: true,
+                      targets: ['defaults', 'not IE 11']
                     }
                   ]
                 ]


### PR DESCRIPTION
- Add minor `corejs` version.
- Use `bugfixes`.
- Add target of `defaults, not IE 11`. This helps with new `BigInt`
  issues.