### PR TITLE
Fail on webpack error.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-karma ChangeLog
 
+## 6.3.0 - 2024-xx-xx
+
+### Changed
+- Fail on webpack error.
+
 ## 6.2.0 - 2024-02-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-karma ChangeLog
 
-## 6.3.0 - 2024-xx-xx
+## 7.0.0 - 2024-xx-xx
 
 ### Changed
 - Fail on webpack error.

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ import {fileURLToPath} from 'node:url';
 import {VueLoaderPlugin} from 'vue-loader';
 import fs from 'node:fs';
 import path from 'node:path';
+import webpack from 'webpack';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -121,7 +122,8 @@ config.karma.config = {
       }
     },
     plugins: [
-      new VueLoaderPlugin()
+      new VueLoaderPlugin(),
+      new webpack.NoEmitOnErrorsPlugin()
     ]
   },
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,7 +22,6 @@ import {fileURLToPath} from 'node:url';
 import {VueLoaderPlugin} from 'vue-loader';
 import fs from 'node:fs';
 import path from 'node:path';
-import webpack from 'webpack';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -123,7 +122,19 @@ config.karma.config = {
     },
     plugins: [
       new VueLoaderPlugin(),
-      new webpack.NoEmitOnErrorsPlugin()
+      // FIXME: improve error handling method
+      function() {
+        this.hooks.done.tap('@bedrock/karma', stats => {
+          if(stats.hasErrors()) {
+            console.error('ERROR: webpack', {
+              errors: stats.hasErrors(),
+              warnings: stats.hasWarnings()
+            });
+            console.log(stats.toString({modules: false, colors: true}));
+            process.exit(1);
+          }
+        });
+      }
     ]
   },
 


### PR DESCRIPTION
If there are webpack errors, karma/karma-webpack will report them, output assets, and continue with tests anyway.  In some cases those tests may still pass, result in an overall test pass, and the webpack failures may not be noticed (for instance when run by a workflow action).

This patch forces a failure at the webpack level.

I wasn't sure where to handle the webpack failure.  Options such as `bail` in the config didn't work.  Ideally karma-webpack would have better handling, but I couldn't figure out how.  The problem with this patch is karma/karma-webpack don't like this forced failure as they expect output assets to have been generated, resulting in a very noisy confusing failure after the webpack errors are printed.  But it does fix the issue of ignored errors.